### PR TITLE
Run for files that end with _test.py

### DIFF
--- a/src/suggestionProvider.ts
+++ b/src/suggestionProvider.ts
@@ -15,7 +15,7 @@ const isPythonTestFile = (document: vscode.TextDocument) => {
         return false;
     }
     const file = parse(document.fileName).base;
-    return file.startsWith("test_") || file.startsWith("conftest");
+    return file.startsWith("test_") || file.endsWith("_test.py") || file.startsWith("conftest");
 };
 
 /**


### PR DESCRIPTION
[Pytest's naming conventions](https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#test-discovery) look for files that match `test_*.py` and `*_test.py`. This updates the suggestion provider to also run on files with names that match the latter.